### PR TITLE
Option (in JS, not in GUI) for user to set a custom timeout at which …

### DIFF
--- a/mainpanel/helena.js
+++ b/mainpanel/helena.js
@@ -5619,7 +5619,23 @@ var WebAutomationLanguage = (function _WebAutomationLanguage() {
       return outputStatements;
     }
 
+    // by default, we'll wait up to 15 seconds for the target node to appear (see ringer/common/common_params.js)
+    // for static pages, this is silly
+    // user may want to provide a custom timeout
+    // this particular function resets the wait for all events in the program, which is easy but not always a good idea
+    this.setCustomTargetTimeout = function _setCustomTargetTimeout(timeoutSeconds){
+      this.traverse(function(statement){
+        if (statement.cleanTrace){
+          for (var i = 0; i < statement.cleanTrace.length; i++){
+            statement.cleanTrace[i].targetTimeout = timeoutSeconds;
+          }
+        }
+      });
+    };
+
   }
+
+  // END of Program
 
   pub.updateBlocklyBlocks = function _updateBlocklyBlocks(program){
     // have to update the current set of blocks based on our pageVars, relations, so on

--- a/ringer-record-replay/content/content_script.js
+++ b/ringer-record-replay/content/content_script.js
@@ -410,6 +410,10 @@ function updateDeltas(target) {
  */
 function checkTimeout(events, startIndex) {
   var timeout = params.replay.targetTimeout;
+  if (events[startIndex].targetTimeout){
+    timeout = events[startIndex].targetTimeout;
+  }
+  console.log("Checking for timeout:", timeout);
   if (timeout != null && timeout > 0) {
     var curTime = new Date().getTime();
 


### PR DESCRIPTION
…point Ringer should stop looking for a given target node.  Not yet clear whether this is sufficiently useful to be surfaced to GUI.